### PR TITLE
Untitled

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,14 @@ npm run dev
 ```
 npm run deploy
 ```
+
+## Swagger API Documentation
+
+To access the Swagger API documentation, follow these steps:
+
+1. Start the development server:
+   ```
+   npm run dev
+   ```
+
+2. Open your browser and navigate to `http://localhost:8787/api-docs` to view the Swagger UI.

--- a/package.json
+++ b/package.json
@@ -4,12 +4,15 @@
     "dev": "wrangler dev",
     "deploy": "wrangler deploy --minify",
     "db:generate": "drizzle-kit generate --dialect=postgresql --schema=./src/db/schema.ts",
-    "db:migrate": "tsx ./src/db/migrate.ts"
+    "db:migrate": "tsx ./src/db/migrate.ts",
+    "generate-docs": "tsx ./src/swagger.ts"
   },
   "dependencies": {
     "@neondatabase/serverless": "^0.10.4",
     "drizzle-orm": "^0.38.3",
-    "hono": "^4.6.15"
+    "hono": "^4.6.15",
+    "swagger-jsdoc": "^6.2.8",
+    "swagger-ui-express": "^4.6.3"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20241218.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { neon } from "@neondatabase/serverless";
 import { drizzle } from "drizzle-orm/neon-http";
 import { Hono } from "hono";
 import { projects } from "./db/schema";
+import { setupSwagger } from "./swagger";
 
 export type Env = {
   DATABASE_URL: string;
@@ -20,5 +21,7 @@ app.get("/projects", async (c) => {
   const allProjects = await db.select().from(projects);
   return c.json(allProjects);
 });
+
+setupSwagger(app);
 
 export default app;

--- a/src/swagger.ts
+++ b/src/swagger.ts
@@ -1,0 +1,20 @@
+import swaggerJsdoc from 'swagger-jsdoc';
+import swaggerUi from 'swagger-ui-express';
+import { Express } from 'express';
+
+const options = {
+  definition: {
+    openapi: '3.0.0',
+    info: {
+      title: 'My API',
+      version: '1.0.0',
+    },
+  },
+  apis: ['./src/index.ts'], // files containing annotations as above
+};
+
+const swaggerSpec = swaggerJsdoc(options);
+
+export const setupSwagger = (app: Express) => {
+  app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
+};


### PR DESCRIPTION
Add Swagger documentation generation for the API.

* **Dependencies**: Add `swagger-jsdoc` and `swagger-ui-express` to `package.json` dependencies.
* **Scripts**: Add a new script `generate-docs` in `package.json` to generate Swagger documentation.
* **Swagger Configuration**: Create `src/swagger.ts` to configure Swagger options and setup Swagger UI.
* **API Integration**: Update `src/index.ts` to import Swagger setup and serve API documentation at `/api-docs`.
* **Documentation**: Update `README.md` with instructions to access Swagger API documentation.

